### PR TITLE
linux: Align asm call constraint back on linux.

### DIFF
--- a/v4v/include/xen/hypercall6.h
+++ b/v4v/include/xen/hypercall6.h
@@ -29,7 +29,7 @@
 #endif
 
 #undef __HYPERCALL_DECLS
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0))
 #define __HYPERCALL_DECLS						    \
 	register unsigned long __res  asm(__HYPERCALL_RETREG);		    \
 	register unsigned long __arg1 asm(__HYPERCALL_ARG1REG) = __arg1;    \


### PR DESCRIPTION
CALL instructions used to list the stack pointer as a constraint.
So this was the case for hypercalls from 4.6 until 4.14.

This is due to the extensions for 6 arguments hypercall made for V4V.

See: linux-stable.git
f5caf621ee35 x86/asm: Fix inline asm call constraints for Clang